### PR TITLE
Remove git logs from prompt generation

### DIFF
--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -9,7 +9,6 @@ from sum_diff.git import (
     git_current_branch,
     git_parent_branch,
     git_diff_from_parent,
-    git_logs_from_parent,
 )
 
 load_dotenv(".env")
@@ -85,11 +84,9 @@ def main():
     current_branch = git_current_branch()
     parent_branch = git_parent_branch(current_branch)
     diff = git_diff_from_parent(parent_branch)
-    logs = git_logs_from_parent(parent_branch)
     # print(current_branch)
     # print(parent_branch)
     # print(diff)
-    # print(logs)
 
     client = anthropic.Anthropic(
         # defaults to os.environ.get("ANTHROPIC_API_KEY")
@@ -100,13 +97,11 @@ def main():
         model="claude-3-5-sonnet-20240620",
         max_tokens=1024,
         temperature=0,
-        system=SYSTEM_PROMPT.format(branch_name=current_branch, logs=logs, diff=diff),
+        system=SYSTEM_PROMPT.format(branch_name=current_branch, diff=diff),
         messages=[
             {
                 "role": "user",
-                "content": USER_PROMPT.format(
-                    branch_name=current_branch, logs=logs, diff=diff
-                ),
+                "content": USER_PROMPT.format(branch_name=current_branch, diff=diff),
             },
         ],
     )

--- a/sum_diff/git.py
+++ b/sum_diff/git.py
@@ -57,14 +57,3 @@ def git_diff_from_parent(parent_branch: str | None) -> str:
     """
     command = f"git diff {parent_branch}.." if parent_branch else "git diff"
     return subprocess.check_output(command, shell=True).decode("utf-8")
-
-
-def git_logs_from_parent(parent_branch: str | None) -> str:
-    """
-    Get the diff of the current branch from its parent branch.
-    """
-    command = "git log --name-only --oneline"
-    if parent_branch:
-        command += f" {parent_branch}.."
-
-    return subprocess.check_output(command, shell=True).decode("utf-8")


### PR DESCRIPTION
This change simplifies the prompt generation process by removing the git logs component. The main modifications include:

1. Removing the `git_logs_from_parent` function from the `git.py` file.
2. Updating the `main` function in `__init__.py` to no longer fetch or use git logs.
3. Modifying the `SYSTEM_PROMPT` and `USER_PROMPT` to exclude references to commit messages.

These changes streamline the code and focus the prompt generation solely on the branch name and diff information.