### PR TITLE
言語選択オプションを追加 (`--lang`)

### DIFF
--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -88,6 +88,10 @@ Your PR description here
 Remember to base your PR title and description solely on the information provided in the branch name
 and code diff. Do not include any external information or assumptions beyond what is given.
 
+**IMPORTANT**:
+
+- Output should be in {lang}.
+
 ## Example Output
 
 Here's an example of how your output might look:
@@ -147,6 +151,7 @@ def main(lang):
         api_key=ANTHROPIC_API_KEY,
     )
 
+    output_lang = "Japanese" if lang == "ja" else "English"
     message = client.messages.create(
         model="claude-3-5-sonnet-20240620",
         max_tokens=1024,
@@ -155,7 +160,9 @@ def main(lang):
         messages=[
             {
                 "role": "user",
-                "content": USER_PROMPT.format(branch_name=current_branch, diff=diff),
+                "content": USER_PROMPT.format(
+                    branch_name=current_branch, diff=diff, lang=output_lang
+                ),
             },
             {"role": "assistant", "content": "<response><pr_title>"},
         ],

--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -126,7 +126,15 @@ This new implementation ensures that passwords are securely hashed and compared,
 
 
 @click.command()
-def main():
+# 言語を選択するオプション。デフォルトは英語であり、日本語を選択することもできる。
+@click.option(
+    "--lang",
+    "-l",
+    type=click.Choice(["en", "ja"], case_sensitive=False),
+    default="en",
+    help="Choose the language for the output.",
+)
+def main(lang):
     current_branch = git_current_branch()
     parent_branch = git_parent_branch(current_branch)
     diff = git_diff_from_parent(parent_branch)


### PR DESCRIPTION
このPRでは、出力言語を選択するためのオプションを追加しました。

主な変更点：
- `main()` 関数に `--lang` オプションを追加
- 英語（デフォルト）と日本語の選択が可能

`click.option` デコレータを使用して、言語選択オプションを実装しました。これにより、ユーザーは出力言語を柔軟に選択できるようになります。

```python
@click.option(
    "--lang",
    "-l",
    type=click.Choice(["en", "ja"], case_sensitive=False),
    default="en",
    help="Choose the language for the output.",
)
def main(lang):
    # 既存のコード
```

このオプションにより、国際化対応が容易になり、日本語を含む多言語サポートの基盤が整いました。今後、他の言語サポートを追加する際にも、この構造を活用できます。