### PR TITLE
Add more examples for few-shot learning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -375,6 +375,17 @@ files = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "jiter"
 version = "0.5.0"
 description = "Fast iterable JSON parser."
@@ -454,6 +465,21 @@ files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pydantic"
@@ -564,6 +590,28 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pytest"
+version = "8.3.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
+    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -789,6 +837,17 @@ docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
 testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests", "ruff"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.66.4"
 description = "Fast, Extensible Progress Meter"
@@ -839,4 +898,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3184ab3bef10f26a83e46b54f4afb3efd404642757961f392535372038bdc08e"
+content-hash = "9b780c24b4264bed4de63c637c11e8df0ac7dcc1f80ef536a94b8cf5c52584b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,18 @@ anthropic = "^0.30.0"
 [tool.poetry.scripts]
 sum-diff = "sum_diff:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.2"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+pythonpath = "."
+testpaths = [
+    "tests",
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -130,14 +130,14 @@ def main(lang):
     # Construct the user prompt
     user_prompt = USER_PROMPT.format(
         branch_name=current_branch, diff=diff, lang=output_lang
-    )
+    ).strip()
 
-    for example in examples:
-        user_prompt += "\n\n## Example Output\n\n"
+    for i, example in enumerate(examples):
+        user_prompt += f"\n\n## Example Output ({i+1})\n\n"
         user_prompt += f"<pr_title>\n{example.title}\n</pr_title>\n\n"
         user_prompt += f"<pr_description>\n{example.description}\n</pr_description>"
 
-    print(user_prompt)
+    # print(user_prompt)
 
     client = anthropic.Anthropic(
         # defaults to os.environ.get("ANTHROPIC_API_KEY")

--- a/sum_diff/examples/001.md
+++ b/sum_diff/examples/001.md
@@ -1,0 +1,31 @@
+<!--
+This is the first example of pull request.
+-->
+
+# Add `UserAuthentication` class to improve login process (#123)
+
+This PR introduces a new `UserAuthentication` class to enhance the login process and improve overall
+security.
+
+Key changes:
+
+- Create `UserAuthentication` class in `auth/user_authentication.rb`
+- Implement password hashing using `bcrypt` gem
+- Update `User` model to utilize the new authentication class
+
+The `UserAuthentication` class encapsulates the login logic and password management, separating
+these concerns from the `User` model. This change improves code organization and makes it easier to
+maintain and extend authentication functionality in the future.
+
+Example usage of the new class:
+
+```ruby
+user_auth = UserAuthentication.new(user)
+if user_auth.authenticate(password)
+  # Proceed with login
+else
+  # Handle authentication failure
+end
+```
+
+This new implementation ensures that passwords are securely hashed and compared, reducing the risk of password-related vulnerabilities.

--- a/sum_diff/examples/002.md
+++ b/sum_diff/examples/002.md
@@ -1,0 +1,49 @@
+<!--
+Based on https://github.com/etcd-io/etcd/pull/14627
+-->
+
+# raft: support asynchronous storage writes
+
+This change adds opt-in support to perform local storage writes asynchronously, reducing interference and increasing batching of log appends and state machine applications.
+
+## Summary
+
+A new `AsyncStorageWrites` option allows the raft node to handle storage asynchronously using a message-passing interface instead of the default `Ready`/`Advance` call. This can reduce commit latency and increase throughput.
+
+When enabled, the `Ready.Message` slice includes `MsgStorageAppend` and `MsgStorageApply` messages, processed by `LocalAppendThread` and `LocalApplyThread`. Messages to the same target must be processed in order.
+
+## Design Considerations
+
+- No regression for users not using `AsyncStorageWrites`.
+- Asynchronous work uses message-passing, with symmetry between leaders and followers.
+- Snapshots can be applied asynchronously, making it easy for users.
+
+## Usage
+
+With `AsyncStorageWrites`, users still read from `Node.Ready()` but handle storage messages differently. The example loop below shows message routing and local storage operations:
+
+```go
+for {
+	select {
+	case <-s.Ticker:
+		n.Tick()
+	case rd := <-s.Node.Ready():
+		for _, m := range rd.Messages {
+			switch m.To {
+			case raft.LocalAppendThread:
+				toAppend <- m
+			case raft.LocalApplyThread:
+				toApply <- m
+			default:
+				sendOverNetwork(m)
+			}
+		}
+	case <-s.done:
+		return
+	}
+}
+```
+
+## Compatibility
+
+This change remains fully backward-compatible and has no cross-version compatibility issues. Nodes can mix synchronous and asynchronous writes without noticeable differences in cluster behavior.

--- a/sum_diff/examples/003.md
+++ b/sum_diff/examples/003.md
@@ -1,0 +1,67 @@
+<!--
+Based on https://github.com/facebook/react/pull/14853
+-->
+
+# await act(async () => ...)
+
+I hacked together an asynchronous version of `act(...)`, and it's kinda nice.
+
+You've seen the synchronous version:
+
+```javascript
+act(() => {
+  // updates and stuff
+});
+// make assertions
+```
+
+This still works, and gives the same warnings. But if you pass an async function:
+
+```javascript
+await act(async () => {
+  // updates and stuff
+});
+// expect commits and effects to be flushed
+// make assertions
+```
+
+Neat! I set it up so if you *don't* `await` the result from `act`, a warning gets triggered (with `setImmediate`) to do so. That makes it a bit harder to have rogue async `act()` calls in the ether.
+
+You can nest `act()` calls:
+
+```javascript
+await act(async () => {
+  // nest synchronous calls
+  act(() => {
+    // updates and such
+  });
+  // as before, updates and effects are flushed
+
+  // make assertions
+  await sleep(500); // or for a promise to resolve, or whatever
+  // more assertions maybe
+
+  // nest asynchronous calls too
+  await act(async () => {
+    // mutations and such
+    // more awaits
+    // and maybe an event or two
+  });
+  // more assertions
+});
+```
+
+I implemented a cheap form of unrolling safety, so if a previous `act()` gets closed before any subsequent `act()` calls, a warning gets triggered. This should prevent most interleaving attempts, and maintain a tree-like shape of `act()` blocks.
+
+**pros**
+
+- works with async/await, solves oss problems cleanly
+- the sync api is preserved
+- the warning is preserved
+- works with fake timers/fb
+
+**cons**
+
+- can't guarantee batching after the first await in an act block (this will get better when concurrent?)
+- less restrictive than the sync model, and starts to feel more opt-in than opt-out (eg- someone could just wrap their entire test with an `act()` call... which might be fine?)
+- exposes a secret api on react dom to implement it, dunno how you feel about that

--- a/sum_diff/utils.py
+++ b/sum_diff/utils.py
@@ -19,8 +19,19 @@ def parse_pr_example(markdown: str) -> PRExample:
     # Remove html comments
     markdown = re.sub(r"<!--.*?-->", "", markdown, flags=re.DOTALL)
 
-    # Split the title and description
-    title, description = re.split(r"\n+", markdown.strip(), maxsplit=1)
+    # Split the title and description.
+    #
+    # The title is the first line which starts with `# `
+    # The description is everything after the title
+    title = ""
+    lines: list[str] = []
+    for line in markdown.splitlines():
+        if line.startswith("# ") and not title:
+            title = line
+        else:
+            lines.append(line)
+
+    description = "\n".join(lines)
 
     # Remove leading `#` from the title
     title = re.sub(r"^#+\s*", "", title)

--- a/sum_diff/utils.py
+++ b/sum_diff/utils.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+import re
+
+
+@dataclass
+class PRExample:
+    title: str
+    description: str
+
+
+def parse_pr_example(markdown: str) -> PRExample:
+    """
+    Parses a PR example from a Markdown-formatted string.
+
+    - Removes html comments like <!-- comment -->
+    - Splits the h1 title and the remaining content
+    - Removes leading and trailing whitespace from the title and description
+    """
+    # Remove html comments
+    markdown = re.sub(r"<!--.*?-->", "", markdown, flags=re.DOTALL)
+
+    # Split the title and description
+    title, description = re.split(r"\n+", markdown.strip(), maxsplit=1)
+
+    # Remove leading `#` from the title
+    title = re.sub(r"^#+\s*", "", title)
+
+    # Remove leading and trailing whitespace from the title and description
+    return PRExample(title.strip(), description.strip())

--- a/sum_diff/utils.py
+++ b/sum_diff/utils.py
@@ -3,12 +3,12 @@ import re
 
 
 @dataclass
-class PRExample:
+class PrExample:
     title: str
     description: str
 
 
-def parse_pr_example(markdown: str) -> PRExample:
+def parse_pr_example(markdown: str) -> PrExample:
     """
     Parses a PR example from a Markdown-formatted string.
 
@@ -37,4 +37,4 @@ def parse_pr_example(markdown: str) -> PRExample:
     title = re.sub(r"^#+\s*", "", title)
 
     # Remove leading and trailing whitespace from the title and description
-    return PRExample(title.strip(), description.strip())
+    return PrExample(title.strip(), description.strip())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,75 @@
+import pytest
 from sum_diff.utils import parse_pr_example, PRExample
 
 
-def test_parse_pr_example():
-    markdown = """
+@pytest.mark.parametrize(
+    "markdown, expected",
+    [
+        # single line comment
+        (
+            """
 <!-- This is a comment -->
 # Title
 
 This section contains the description.
-"""
-    expected = PRExample(
-        title="Title", description="This section contains the description."
-    )
+""",
+            PRExample(
+                title="Title", description="This section contains the description."
+            ),
+        ),
+        # multiline comment
+        (
+            """
+<!--
+    This is a comment
+-->
+# Title
 
+This section contains the description.
+""",
+            PRExample(
+                title="Title", description="This section contains the description."
+            ),
+        ),
+        # multiple comments
+        (
+            """
+<!--
+    This is a comment
+-->
+<!--
+    This is another comment
+-->
+# Title
+
+This section contains the description.
+""",
+            PRExample(
+                title="Title", description="This section contains the description."
+            ),
+        ),
+        # multiple headings
+        (
+            """
+# Title
+
+This section contains the description.
+
+## Section A
+
+This section contains the additional information.
+
+""",
+            PRExample(
+                title="Title",
+                description="""This section contains the description.
+
+## Section A
+
+This section contains the additional information.""",
+            ),
+        ),
+    ],
+)
+def test_parse_pr_example(markdown: str, expected: PRExample) -> None:
     assert parse_pr_example(markdown) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from sum_diff.utils import parse_pr_example, PRExample
+
+
+def test_parse_pr_example():
+    markdown = """
+<!-- This is a comment -->
+# Title
+
+This section contains the description.
+"""
+    expected = PRExample(
+        title="Title", description="This section contains the description."
+    )
+
+    assert parse_pr_example(markdown) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from sum_diff.utils import parse_pr_example, PRExample
+from sum_diff.utils import parse_pr_example, PrExample
 
 
 @pytest.mark.parametrize(
@@ -13,7 +13,7 @@ from sum_diff.utils import parse_pr_example, PRExample
 
 This section contains the description.
 """,
-            PRExample(
+            PrExample(
                 title="Title", description="This section contains the description."
             ),
         ),
@@ -27,7 +27,7 @@ This section contains the description.
 
 This section contains the description.
 """,
-            PRExample(
+            PrExample(
                 title="Title", description="This section contains the description."
             ),
         ),
@@ -44,7 +44,7 @@ This section contains the description.
 
 This section contains the description.
 """,
-            PRExample(
+            PrExample(
                 title="Title", description="This section contains the description."
             ),
         ),
@@ -60,7 +60,7 @@ This section contains the description.
 This section contains the additional information.
 
 """,
-            PRExample(
+            PrExample(
                 title="Title",
                 description="""This section contains the description.
 
@@ -71,5 +71,5 @@ This section contains the additional information.""",
         ),
     ],
 )
-def test_parse_pr_example(markdown: str, expected: PRExample) -> None:
+def test_parse_pr_example(markdown: str, expected: PrExample) -> None:
     assert parse_pr_example(markdown) == expected


### PR DESCRIPTION
This PR enhances the few-shot learning capabilities of our project by adding more example outputs and implementing a parsing mechanism for these examples.

Key changes:
- Added new example PR outputs in Markdown format (`sum_diff/examples/001.md`, `002.md`, and `003.md`)
- Implemented `parse_pr_example` function in `sum_diff/utils.py` to process example PR outputs
- Updated `main` function in `sum_diff/__init__.py` to incorporate example outputs into the user prompt
- Added unit tests for the `parse_pr_example` function in `tests/test_utils.py`
- Updated `pyproject.toml` to include pytest configuration and dev dependencies

The new examples provide a diverse set of PR formats, including different styles and complexities. This will help improve the quality and variety of generated PR titles and descriptions.

The `parse_pr_example` function extracts the title and description from the Markdown-formatted example files, handling HTML comments and multiple headings. This parsed data is then incorporated into the user prompt, allowing for more effective few-shot learning.

Example usage of the new `parse_pr_example` function:

```python
from sum_diff.utils import parse_pr_example

markdown_content = """
<!-- This is a comment -->
# Example PR Title

This is the PR description.
"""

pr_example = parse_pr_example(markdown_content)
print(pr_example.title)  # Output: Example PR Title
print(pr_example.description)  # Output: This is the PR description.
```

These changes will enhance the AI model's ability to generate more accurate and contextually appropriate PR titles and descriptions based on the provided examples.