### PR TITLE
Add verbose logging option to main function

### DIFF
--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -1,18 +1,15 @@
+import logging
 import os
-from os import path
 import re
-import click
 import xml.etree.ElementTree as ET
+from os import path
 
-from dotenv import load_dotenv
 import anthropic
+import click
+from dotenv import load_dotenv
 
-
-from sum_diff.git import (
-    git_current_branch,
-    git_parent_branch,
-    git_diff_from_parent,
-)
+from sum_diff.git import git_current_branch, git_diff_from_parent, git_parent_branch
+from sum_diff.logger import logger
 from sum_diff.utils import parse_pr_example
 
 load_dotenv(".env")
@@ -105,16 +102,25 @@ and code diff. Do not include any external information or assumptions beyond wha
     default="en",
     help="Choose the language for the output.",
 )
-def main(lang):
+@click.option(
+    "-v", "--verbose", is_flag=True, default=False, help="Enable verbose logging."
+)
+def main(lang, verbose=False):
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
     output_lang = "Japanese" if lang == "ja" else "English"
 
     # Git operations
     current_branch = git_current_branch()
     parent_branch = git_parent_branch(current_branch)
     diff = git_diff_from_parent(parent_branch)
-    # print(current_branch)
-    # print(parent_branch)
-    # print(diff)
+
+    logger.debug(f"Current branch: {current_branch}")
+    logger.debug(f"Parent branch: {parent_branch}")
+    logger.debug(f"Diff: {diff}")
 
     # Read example outputs for few shots learning from the directory "examples/"
     examples_dir = path.join(path.dirname(__file__), "examples")

--- a/sum_diff/logger.py
+++ b/sum_diff/logger.py
@@ -1,0 +1,6 @@
+import logging
+
+logging.basicConfig(format="%(levelname)s: %(message)s")
+logger = logging.getLogger("sum_diff")
+
+logger.setLevel(logging.INFO)


### PR DESCRIPTION
This PR introduces a new verbose logging option to the main function of the sum_diff package. The changes improve debugging capabilities and provide more detailed information during execution.

Main changes:
1. Added a new `-v` or `--verbose` flag to the `main` function using `click.option`.
2. Implemented conditional logging level setting based on the verbose flag.
3. Replaced print statements with debug logging for git operations.
4. Imported the `logger` from a new `sum_diff.logger` module.

Implementation details:
- The verbose flag is set to `False` by default.
- When verbose mode is enabled, the logging level is set to `DEBUG`; otherwise, it remains at `INFO`.
- Git operation results (current branch, parent branch, and diff) are now logged using `logger.debug()`.

Example usage:
```python
@click.option(
    "-v", "--verbose", is_flag=True, default=False, help="Enable verbose logging."
)
def main(lang, verbose=False):
    if verbose:
        logger.setLevel(logging.DEBUG)
    else:
        logger.setLevel(logging.INFO)
```

This change allows users to run the script with more detailed logging when needed, facilitating easier debugging and troubleshooting.