### PR TITLE
Add `--base` option for specifying base branch comparison

### DIFF
--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -103,9 +103,17 @@ and code diff. Do not include any external information or assumptions beyond wha
     help="Choose the language for the output.",
 )
 @click.option(
+    "--base",
+    "-b",
+    "base_branch",
+    type=str,
+    default=None,
+    help="Specify the base branch to compare against.",
+)
+@click.option(
     "-v", "--verbose", is_flag=True, default=False, help="Enable verbose logging."
 )
-def main(lang, verbose=False):
+def main(lang, base_branch, verbose=False):
     if verbose:
         logger.setLevel(logging.DEBUG)
     else:
@@ -115,11 +123,14 @@ def main(lang, verbose=False):
 
     # Git operations
     current_branch = git_current_branch()
-    base_branch = git_base_branch(current_branch)
+
+    if base_branch is None:
+        base_branch = git_base_branch(current_branch)
+
     diff = git_diff_from_parent(base_branch)
 
     logger.debug(f"Current branch: {current_branch}")
-    logger.debug(f"Parent branch: {base_branch}")
+    logger.debug(f"Base branch: {base_branch}")
     logger.debug(f"Diff: {diff}")
 
     # Read example outputs for few shots learning from the directory "examples/"

--- a/sum_diff/__init__.py
+++ b/sum_diff/__init__.py
@@ -8,7 +8,7 @@ import anthropic
 import click
 from dotenv import load_dotenv
 
-from sum_diff.git import git_current_branch, git_diff_from_parent, git_parent_branch
+from sum_diff.git import git_base_branch, git_current_branch, git_diff_from_parent
 from sum_diff.logger import logger
 from sum_diff.utils import parse_pr_example
 
@@ -115,11 +115,11 @@ def main(lang, verbose=False):
 
     # Git operations
     current_branch = git_current_branch()
-    parent_branch = git_parent_branch(current_branch)
-    diff = git_diff_from_parent(parent_branch)
+    base_branch = git_base_branch(current_branch)
+    diff = git_diff_from_parent(base_branch)
 
     logger.debug(f"Current branch: {current_branch}")
-    logger.debug(f"Parent branch: {parent_branch}")
+    logger.debug(f"Parent branch: {base_branch}")
     logger.debug(f"Diff: {diff}")
 
     # Read example outputs for few shots learning from the directory "examples/"

--- a/sum_diff/git.py
+++ b/sum_diff/git.py
@@ -14,7 +14,7 @@ def git_current_branch() -> str:
 
 
 # Borrowed from https://stackoverflow.com/a/17843908
-def git_parent_branch(current_branch: str) -> str | None:
+def git_base_branch(current_branch: str) -> str | None:
     """
     Find the nearest parent of a Git branch and return its name.
     """


### PR DESCRIPTION
This PR introduces a new `--base` command-line option to allow users to specify a custom base branch for comparison in the `sum_diff` tool.

Main changes:
1. Added a new `--base` (`-b`) option to the `main` function in `sum_diff/__init__.py`.
2. Renamed `git_parent_branch` function to `git_base_branch` in `sum_diff/git.py`.
3. Updated the logic to use the specified base branch or fall back to the default base branch.

Implementation details:
- The `--base` option is optional and defaults to `None`.
- If no base branch is specified, the tool will use the `git_base_branch` function to determine the default base branch.
- Updated import statements and function calls to reflect the renamed `git_base_branch` function.

This change provides more flexibility for users who want to compare their current branch against a specific base branch, rather than relying on the automatically determined parent branch.
